### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,16 +11,16 @@ ATSerial	KEYWORD1
 ATSerial_WiFi	KEYWORD1
 
 # From ATSerial.h
-isOkay      KEYWORD2
-restart     KEYWORD2
-available   KEYWORD2
-read        KEYWORD2
-readString  KEYWORD2
+isOkay	KEYWORD2
+restart	KEYWORD2
+available	KEYWORD2
+read	KEYWORD2
+readString	KEYWORD2
 
 # From ATSerial_WiFi.h
-joinAP      KEYWORD2
-setAP       KEYWORD2
-tcpServer   KEYWORD2
+joinAP	KEYWORD2
+setAP	KEYWORD2
+tcpServer	KEYWORD2
 
 # Literals
 RXDEFAULT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords